### PR TITLE
Add Hex Colorcodes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.quickwrite</groupId>
     <artifactId>noplayernotifier</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <packaging>jar</packaging>
 
     <name>NoPlayerNotifier</name>

--- a/src/main/java/net/quickwrite/noplayernotifier/listeners/MessageListener.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/listeners/MessageListener.java
@@ -1,6 +1,7 @@
 package net.quickwrite.noplayernotifier.listeners;
 
 import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.ChatEvent;
 import net.md_5.bungee.api.plugin.Listener;

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/Pair.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/Pair.java
@@ -4,15 +4,31 @@ public class Pair<T, E> {
     private final T value1;
     private final E value2;
 
+    /**
+     * Crates the Pair of two values.
+     *
+     * @param value1 The first value
+     * @param value2 The second value
+     */
     public Pair(T value1, E value2) {
         this.value1 = value1;
         this.value2 = value2;
     }
 
+    /**
+     * Gets the first value of the pair
+     *
+     * @return the first value
+     */
     public T getValue1() {
         return value1;
     }
 
+    /**
+     * Gets the second value of the pair
+     *
+     * @return The second value
+     */
     public E getValue2() {
         return value2;
     }

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/Pair.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/Pair.java
@@ -1,0 +1,19 @@
+package net.quickwrite.noplayernotifier.utils;
+
+public class Pair<T, E> {
+    private final T value1;
+    private final E value2;
+
+    public Pair(T value1, E value2) {
+        this.value1 = value1;
+        this.value2 = value2;
+    }
+
+    public T getValue1() {
+        return value1;
+    }
+
+    public E getValue2() {
+        return value2;
+    }
+}

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/config/Config.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/config/Config.java
@@ -1,8 +1,8 @@
 package net.quickwrite.noplayernotifier.utils.config;
 
-import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.config.Configuration;
+import net.quickwrite.noplayernotifier.utils.format.MessageFormatter;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -87,7 +87,7 @@ public final class Config {
      * @return The TextComponent
      */
     private TextComponent createTextComponent(List<String> text) {
-        return new TextComponent(format(concatenateStrings(msgPrefix, text)));
+        return new TextComponent(MessageFormatter.format(concatenateStrings(msgPrefix, text)));
     }
 
     /**
@@ -100,17 +100,6 @@ public final class Config {
      */
     private String concatenateStrings(String prefix, List<String> messages) {
         return prefix + String.join("\n", messages);
-    }
-
-    /**
-     * Formats the message by translating the
-     * colorcodes with an '&'
-     *
-     * @param string The message that should be translated.
-     * @return The translated message.
-     */
-    private String format(String string) {
-        return ChatColor.translateAlternateColorCodes('&', string);
     }
 
     /**

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/format/MessageFormatter.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/format/MessageFormatter.java
@@ -71,7 +71,7 @@ public final class MessageFormatter {
      * @return An array of TextComponents that resemble the message
      */
     public static TextComponent[] format(String message) {
-        MessageIterator messageIterator = new MessageIterator(message, '&');
+        MessageIterator messageIterator = new MessageIterator(message);
 
         List<TextComponent> textComponentList = new ArrayList<>();
 

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/format/MessageFormatter.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/format/MessageFormatter.java
@@ -5,7 +5,71 @@ import net.md_5.bungee.api.chat.TextComponent;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * A simple class that is there for formatting messages
+ *
+ * @author QuickWrite
+ */
 public final class MessageFormatter {
+
+    /**
+     * Formats the message with color codes
+     * and custom hex codes. <br>
+     *
+     * All of the color codes are case-insensitive. <br><br>
+     *
+     * The color codes from <code>1</code>-<code>f</code> can
+     * be used with an <code>&</code>.
+     * They behave exactly like the color codes
+     * Minecraft itself gives with the <code>§</code>. <br><br>
+     *
+     * Also the attributes that make the message
+     * bold (<code>l</code>), italic (<code>o</code>),
+     * underlined (<code>n</code>), strikethrough (<code>m</code>)
+     * can be used. These stack on top of each other
+     * which means that a single segment can use
+     * multiple attributes: <code>&m&lmessage</code> <br><br>
+     *
+     * To reset all of the styles the code <code>r</code>
+     * can be used. <br>
+     *
+     * So a message with the standard Minecraft color codes
+     * would look like this: <br><br>
+     *
+     * <code>&4&lThis&r is a &1simple&r &8&nexamp&lle &4message</code>
+     *
+     * <br><br>
+     * <!-- Separate the two parts -->
+     * <hr>
+     *
+     * To use Hexadecimal colors the message must contain
+     * the identifier (which is <code>&</code>) and a
+     * <code>#</code> symbol. After that the hex
+     * color code will start.
+     * The hex color code will stop when there is
+     * a character that is not in the range of
+     * <code>0</code>-<code>f</code> or there is a <code>;</code>. <br><br>
+     *
+     * So when a message starts with a letter like an <code>a</code>
+     * the message should use a <code>;</code> so that this
+     * letter is not read as a part of the hex color code. <br><br>
+     *
+     * When the hex color code is not valid it will be read
+     * as a normal string and included into the message. <br><br>
+     *
+     * So a message with hex color codes would look
+     * like this: <br><br>
+     *
+     * <code>&#da6000;A simple&r test &#B7088Amessage.</code><br><br>
+     *
+     * <hr>
+     *
+     * Both of the ways of formatting a message - as seen
+     * in the previous example - can be used together.
+     *
+     * @param message The raw message as a string
+     * @return An array of TextComponents that resemble the message
+     */
     public static TextComponent[] format(String message) {
         MessageIterator messageIterator = new MessageIterator(message, '&');
 

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/format/MessageFormatter.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/format/MessageFormatter.java
@@ -1,0 +1,24 @@
+package net.quickwrite.noplayernotifier.utils.format;
+
+import net.md_5.bungee.api.chat.TextComponent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class MessageFormatter {
+    public static TextComponent[] format(String message) {
+        MessageIterator messageIterator = new MessageIterator(message, '&');
+
+        List<TextComponent> textComponentList = new ArrayList<>();
+
+        TextComponent nextItem = messageIterator.toNext();
+
+        while(nextItem != null) {
+            textComponentList.add(nextItem);
+
+            nextItem = messageIterator.toNext();
+        }
+
+        return textComponentList.toArray(new TextComponent[0]);
+    }
+}

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/format/MessageIterator.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/format/MessageIterator.java
@@ -6,6 +6,12 @@ import net.quickwrite.noplayernotifier.utils.Pair;
 
 import java.awt.*;
 
+/**
+ * An iterator to format the messages with
+ * hexadecimal color codes.
+ *
+ * @author QuickWrite
+ */
 public class MessageIterator {
     private final String message;
     private int iterator = -1;
@@ -20,11 +26,24 @@ public class MessageIterator {
     private ChatColor currentColor = getResetColor();
     private final Attributes attributes = new Attributes();
 
+    /**
+     * Initializes the message iterator with the
+     * respective values.
+     *
+     * @param message The message that should be iterated over.
+     * @param identifier The iterator that should be used by the iterator
+     */
     public MessageIterator(final String message, char identifier) {
         this.message = message + "-";
         this.identifier = identifier;
     }
 
+    /**
+     * Gets the TextComponent that has the formatted
+     * message to the next code.
+     *
+     * @return A formatted TextComponent
+     */
     public TextComponent toNext() {
         if(!inBounds())
             return null;
@@ -53,6 +72,11 @@ public class MessageIterator {
         return component;
     }
 
+    /**
+     * Checks if a code is valid.
+     *
+     * @return the number of steps that should be backtracked.
+     */
     private int getNextCode() {
         if (!inBounds())
             return 0;
@@ -90,6 +114,12 @@ public class MessageIterator {
         return 0;
     }
 
+    /**
+     * Gets the hex color code
+     *
+     * @return the ChatColor with the color code and the number
+     *         of steps that should be backtracked.
+     */
     private Pair<ChatColor, Integer> getHex() {
         if(!inBounds())
             return null;
@@ -123,23 +153,49 @@ public class MessageIterator {
         }
     }
 
+    /**
+     * Checks if the iterator is in bounds.
+     *
+     * @return if the iterator is in bounds
+     */
     private boolean inBounds() {
         return message.length() > (iterator + 1);
     }
 
+    /**
+     * Returns the next character.
+     *
+     * @return the next character
+     */
     private char getNext() {
         iterator++;
         return message.charAt(iterator);
     }
 
+    /**
+     * Returns the color that is the default
+     * color of the message.
+     *
+     * @return the default ChatColor
+     */
     private ChatColor getResetColor() {
         return ChatColor.of(Color.WHITE);
     }
 
+    /**
+     * Checks if a character is in a String.
+     *
+     * @param list The String that should be checked.
+     * @param character The char that should be in the String
+     * @return If the char is in the String
+     */
     private boolean contains(String list, char character) {
         return list.contains(Character.toLowerCase(character) + "");
     }
 
+    /**
+     * Stores the attributes of a message
+     */
     private static class Attributes {
         private boolean isBold = false;
         private boolean isItalic = false;
@@ -147,6 +203,12 @@ public class MessageIterator {
         private boolean isStrikethrough = false;
         private boolean isObfuscated = false;
 
+        /**
+         * Adds the attributes to the TextComponent
+         *
+         * @param component The TextComponent
+         * @return The TextComponent
+         */
         public TextComponent addAttributes(final TextComponent component) {
             component.setBold(isBold);
             component.setItalic(isItalic);
@@ -157,6 +219,11 @@ public class MessageIterator {
             return component;
         }
 
+        /**
+         * Sets the attribute inside the object
+         *
+         * @param character The character that is the attribute.
+         */
         public void set(final char character) {
             switch (character) {
                 case 'l':
@@ -176,6 +243,9 @@ public class MessageIterator {
             }
         }
 
+        /**
+         * Resets all of the attributes
+         */
         public void reset() {
             isBold = false;
             isItalic = false;

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/format/MessageIterator.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/format/MessageIterator.java
@@ -30,6 +30,20 @@ public class MessageIterator {
      * Initializes the message iterator with the
      * respective values.
      *
+     * <br><br>
+     *
+     * Sets the identifier to the value <code>&</code>.
+     *
+     * @param message The message that should be iterated over.
+     */
+    public MessageIterator(final String message) {
+        this(message, '&');
+    }
+
+    /**
+     * Initializes the message iterator with the
+     * respective values.
+     *
      * @param message The message that should be iterated over.
      * @param identifier The iterator that should be used by the iterator
      */
@@ -52,7 +66,7 @@ public class MessageIterator {
 
         TextComponent component = new TextComponent();
         component.setColor(currentColor);
-        component = attributes.addAttributes(component);
+        attributes.addAttributes(component);
 
         char character;
         int back = 0;
@@ -209,14 +223,12 @@ public class MessageIterator {
          * @param component The TextComponent
          * @return The TextComponent
          */
-        public TextComponent addAttributes(final TextComponent component) {
+        public void addAttributes(TextComponent component) {
             component.setBold(isBold);
             component.setItalic(isItalic);
             component.setUnderlined(isUnderlined);
             component.setStrikethrough(isStrikethrough);
             component.setObfuscated(isObfuscated);
-
-            return component;
         }
 
         /**

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/format/MessageIterator.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/format/MessageIterator.java
@@ -15,6 +15,7 @@ public class MessageIterator {
     private static final String ATTRIBUTE_CHARS = "klmno";
     private static final char RESET_IDENTIFIER = 'r';
     private static final char HEX_IDENTIFIER = '#';
+    private static final char DELIMITER = ';';
 
     private ChatColor currentColor = getResetColor();
     private final Attributes attributes = new Attributes();
@@ -95,9 +96,15 @@ public class MessageIterator {
 
         int start = iterator + 1;
         char character;
+        boolean delimiter = false;
 
         while(inBounds()) {
             character = getNext();
+
+            if(character == DELIMITER) {
+                delimiter = true;
+                break;
+            }
 
             if (!contains(COLOR_CHARS, character)) {
                 iterator--;
@@ -107,7 +114,7 @@ public class MessageIterator {
         }
 
         try {
-            Color color = Color.decode("#" + message.substring(start, iterator));
+            Color color = Color.decode("#" + message.substring(start, iterator + (delimiter ? 0 : 1) ));
 
             return new Pair<>(ChatColor.of(color), iterator - start + 2);
         } catch (NumberFormatException

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/format/MessageIterator.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/format/MessageIterator.java
@@ -1,0 +1,172 @@
+package net.quickwrite.noplayernotifier.utils.format;
+
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.TextComponent;
+
+import java.awt.*;
+
+public class MessageIterator {
+    private final String message;
+    private int iterator = -1;
+    private final char identifier;
+
+    private static final String COLOR_CHARS = "0123456789abcdef";
+    private static final String ATTRIBUTE_CHARS = "klmno";
+    private static final char RESET_IDENTIFIER = 'r';
+    private static final char HEX_IDENTIFIER = '#';
+
+    private ChatColor currentColor = getResetColor();
+    private final Attributes attributes = new Attributes();
+
+    public MessageIterator(final String message, char identifier) {
+        this.message = message + "-";
+        this.identifier = identifier;
+    }
+
+    public TextComponent toNext() {
+        if(!inBounds())
+            return null;
+
+        int start = iterator + 1;
+
+        TextComponent component = new TextComponent();
+        component.setColor(currentColor);
+
+        char character;
+
+        while(inBounds()) {
+            character = getNext();
+
+            if(character == identifier && getNextCode()) {
+                break;
+            }
+        }
+
+        component.setText(message.substring(start, iterator));
+
+        return component;
+    }
+
+    private boolean getNextCode() {
+        if (!inBounds())
+            return false;
+
+        char character = getNext();
+
+        if(HEX_IDENTIFIER == character) {
+            final ChatColor buffer = getHex();
+
+            if(buffer == null)
+                return false;
+
+            currentColor = buffer;
+            return true;
+        }
+
+        if (Character.toLowerCase(character) == RESET_IDENTIFIER) {
+            currentColor = getResetColor();
+            attributes.reset();
+
+            return true;
+        }
+
+        if(contains(COLOR_CHARS, character)) {
+            currentColor = ChatColor.getByChar(character);
+
+            return true;
+        } else if(contains(ATTRIBUTE_CHARS, character)) {
+            attributes.set(character);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private ChatColor getHex() {
+        int start = iterator + 1;
+        char character;
+
+        while(inBounds()) {
+            character = getNext();
+
+            if (!contains(COLOR_CHARS, character)) {
+                iterator--;
+
+                break;
+            }
+        }
+
+        try {
+            Color color = Color.decode("#" + message.substring(start, iterator));
+
+            return ChatColor.of(color);
+        } catch (NumberFormatException
+                | StringIndexOutOfBoundsException exception) {
+            return null;
+        }
+    }
+
+    private boolean inBounds() {
+        return message.length() > (iterator + 1);
+    }
+
+    private char getNext() {
+        iterator++;
+        return message.charAt(iterator);
+    }
+
+    private ChatColor getResetColor() {
+        return ChatColor.of(Color.WHITE);
+    }
+
+    private boolean contains(String list,char character) {
+        return list.contains(Character.toLowerCase(character) + "");
+    }
+
+    private static class Attributes {
+        private boolean isBold = false;
+        private boolean isItalic = false;
+        private boolean isUnderlined = false;
+        private boolean isStrikethrough = false;
+        private boolean isObfuscated = false;
+
+        public TextComponent addAttributes(final TextComponent component) {
+            component.setBold(isBold);
+            component.setItalic(isItalic);
+            component.setUnderlined(isUnderlined);
+            component.setStrikethrough(isStrikethrough);
+            component.setObfuscated(isObfuscated);
+
+            return component;
+        }
+
+        public void set(final char character) {
+            switch (character) {
+                case 'l':
+                    isBold = true;
+                    return;
+                case 'o':
+                    isItalic = true;
+                    return;
+                case 'n':
+                    isUnderlined = true;
+                    return;
+                case 'm':
+                    isStrikethrough = true;
+                    return;
+                case 'k':
+                    isObfuscated = true;
+                    return;
+            }
+        }
+
+        public void reset() {
+            isBold = false;
+            isItalic = false;
+            isUnderlined = false;
+            isStrikethrough = false;
+            isObfuscated = false;
+        }
+    }
+}


### PR DESCRIPTION
Add new Hexadecimal color codes like `&#FFFFFF;`.

```txt
Formats the message with color codes
and custom hex codes.

All of the color codes are case-insensitive.

----------------------------------------------------------

The color codes from 1-f can
be used with an &.
They behave exactly like the color codes
Minecraft itself gives with the §.

Also the attributes that make the message
bold (l), italic (o),
underlined (n), strikethrough (m)
can be used. These stack on top of each other
which means that a single segment can use
multiple attributes: &m&lmessage

To reset all of the styles the code r
can be used.

So a message with the standard Minecraft color codes
would look like this:

&4&lThis&r is a &1simple&r &8&nexamp&lle &4message

----------------------------------------------------------

To use Hexadecimal colors the message must contain
the identifier (which is &) and a
# symbol. After that the hex
color code will start.
The hex color code will stop when there is
a character that is not in the range of
0-f or there is a ;.

So when a message starts with a letter like an a
the message should use a ; so that this
letter is not read as a part of the hex color code.

When the hex color code is not valid it will be read
as a normal string and included into the message.

So a message with hex color codes would look
like this:

&#da6000;A simple&r test &#B7088Amessage.

----------------------------------------------------------

Both of the ways of formatting a message - as seen
in the previous example - can be used together.
```

This sets new possibilities for the messages.