### PR TITLE
Create better JavaDocs

### DIFF
--- a/src/main/java/net/quickwrite/noplayernotifier/commands/NPNReload.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/commands/NPNReload.java
@@ -20,7 +20,7 @@ public final class NPNReload extends Command implements TabExecutor {
     private final NoPlayerNotifier noPlayerNotifier;
 
     /**
-     * The <code>NPNReload</code> command that allows
+     * The {@code NPNReload} command that allows
      * the sender to reload the config so that
      * the Bungee does not reload itself.
      *
@@ -36,8 +36,8 @@ public final class NPNReload extends Command implements TabExecutor {
 
     /**
      * Executes when a player sends the command
-     * <code>/npnreload</code> in chat or the
-     * console is sending <code>npnreload</code>
+     * {@code /npnreload} in chat or the
+     * console is sending {@code npnreload}
      *
      * @param sender The sender of the command
      * @param args The arguments the command has
@@ -71,7 +71,7 @@ public final class NPNReload extends Command implements TabExecutor {
 
     /**
      * Checks if the sender has the
-     * <code>noplayernotifier.reload</code> permission
+     * {@code noplayernotifier.reload} permission
      *
      * @param sender The sender of the command
      * @return If the sender has the permission

--- a/src/main/java/net/quickwrite/noplayernotifier/listeners/MessageListener.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/listeners/MessageListener.java
@@ -1,7 +1,6 @@
 package net.quickwrite.noplayernotifier.listeners;
 
 import net.md_5.bungee.api.ProxyServer;
-import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.ChatEvent;
 import net.md_5.bungee.api.plugin.Listener;
@@ -25,6 +24,7 @@ public class MessageListener implements Listener {
      * message.
      *
      * @param config The messages that are saved in the config
+     * @param channelType The {@link ChannelType} so that the messages can be checked accordingly.
      */
     public MessageListener(final Config config, final ChannelType channelType) {
         this.config = config;

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/Pair.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/Pair.java
@@ -1,5 +1,12 @@
 package net.quickwrite.noplayernotifier.utils;
 
+/**
+ * A simple Pair that holds two seperate values.
+ *
+ * @author QuickWrite
+ * @param <T> The first value
+ * @param <E> The second value
+ */
 public class Pair<T, E> {
     private final T value1;
     private final E value2;

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/Permission.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/Permission.java
@@ -1,15 +1,24 @@
 package net.quickwrite.noplayernotifier.utils;
 
 /**
+ * The permissions that the plugin is checking.
+ *
  * @author QuickWrite
  */
 public enum Permission {
+    /**
+     * The permission for the {@code reload} command.
+     */
     RELOAD,
+
+    /**
+     * The permission so that no message will be send.
+     */
     BYPASS;
 
     /**
      * Returns a String variant of the permission
-     * with a <code>noplayernotifier.</code> in front
+     * with a {@code noplayernotifier.} in front
      *
      * @return The whole permission
      */

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/Permission.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/Permission.java
@@ -18,7 +18,7 @@ public enum Permission {
 
     /**
      * Returns a String variant of the permission
-     * with a {@code noplayernotifier.} in front
+     * with {@code noplayernotifier.} in front.
      *
      * @return The whole permission
      */

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/channel/ChannelType.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/channel/ChannelType.java
@@ -2,12 +2,16 @@ package net.quickwrite.noplayernotifier.utils.channel;
 
 import net.md_5.bungee.api.event.ChatEvent;
 
+/**
+ * The ChannelType the message
+ * should be checked against.
+ */
 public abstract class ChannelType {
     /**
      * Checks if the message is send in the local chat
      * or if the message is send in a different chat.
      *
-     * @param event The <code>ChatEvent</code> that is checked
+     * @param event The {@link ChatEvent} that is checked
      * @param prefix The prefix that is stored in the config
      * @return If the message is send in the local chat
      */

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/channel/ChannelTypeBungeeChat.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/channel/ChannelTypeBungeeChat.java
@@ -6,6 +6,10 @@ import net.md_5.bungee.api.event.ChatEvent;
 
 import java.util.Objects;
 
+/**
+ * The {@link ChannelType} message checker
+ * if there is BungeeChat installed.
+ */
 public final class ChannelTypeBungeeChat extends ChannelType {
     /**
      * Checks if the message is send in the local chat
@@ -15,7 +19,7 @@ public final class ChannelTypeBungeeChat extends ChannelType {
      * it checks if the message is send in the BungeeChat
      * LOCAL chat as well.
      *
-     * @param event The <code>ChatEvent</code> that is checked
+     * @param event The {@link ChatEvent} that is checked
      * @param prefix The prefix that is stored in the config
      * @return If the message is send in the local chat
      */
@@ -32,6 +36,7 @@ public final class ChannelTypeBungeeChat extends ChannelType {
      * @return The channel type
      */
     private dev.aura.bungeechat.api.enums.ChannelType getChannelType(final ProxiedPlayer player) {
-        return Objects.requireNonNull(AccountManager.getAccount(player.getUniqueId()).orElse(null)).getChannelType();
+        return Objects.requireNonNull(AccountManager.getAccount(player.getUniqueId()).orElse(null))
+                .getChannelType();
     }
 }

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/channel/ChannelTypeChat.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/channel/ChannelTypeChat.java
@@ -2,6 +2,11 @@ package net.quickwrite.noplayernotifier.utils.channel;
 
 import net.md_5.bungee.api.event.ChatEvent;
 
+/**
+ * The {@link ChannelType} if no
+ * other Chat Plugin is installed that
+ * is supported.
+ */
 public final class ChannelTypeChat extends ChannelType {
     /**
      * Checks if the message is send in the local chat
@@ -11,7 +16,7 @@ public final class ChannelTypeChat extends ChannelType {
      * like this if the message itself is send with the intention
      * of sending it to multiple servers in mind.
      *
-     * @param event The <code>ChatEvent</code> that is checked
+     * @param event The {@link ChatEvent} that is checked
      * @param prefix The prefix that is stored in the config
      * @return If the message is send in the local chat
      */

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/config/CommandList.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/config/CommandList.java
@@ -20,7 +20,7 @@ public final class CommandList {
     private final Map<String, Command> commands = new HashMap<>();
 
     /**
-     * Adds a single command to the <code>commands</code>
+     * Adds a single command to the {@code commands}
      * HashMap with the return message and the permission
      *
      * @param command The command itself
@@ -34,7 +34,7 @@ public final class CommandList {
     /**
      * Returns the message of the command
      *
-     * If there is no command the return will be <code>null</code>
+     * If there is no command the return will be {@code null}
      *
      * @param command The command
      * @return The message that should be send

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/config/Config.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/config/Config.java
@@ -125,9 +125,9 @@ public final class Config {
     }
 
     /**
-     * Returns the message for a command and <code>null</code> if it does not exist.
+     * Returns the message for a command and {@code null} if it does not exist.
      *
-     * @param command The command itself (<code>/</code> not included)
+     * @param command The command itself ({@code /} not included)
      * @return A TextComponent that has the message that should be send to the player
      */
     public CommandList.Command getCommand(String command) {
@@ -150,6 +150,11 @@ public final class Config {
         );
     }
 
+    /**
+     * Returns the prefix stored in the config
+     *
+     * @return The prefix
+     */
     public String getPrefix() {
         return prefix;
     }

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/format/MessageFormatter.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/format/MessageFormatter.java
@@ -13,59 +13,66 @@ import java.util.List;
 public final class MessageFormatter {
 
     /**
-     * Formats the message with color codes
-     * and custom hex codes. <br>
+     * <p>Formats the message with color codes
+     * and custom hex codes.</p>
      *
-     * All of the color codes are case-insensitive. <br><br>
+     * <p>All of the color codes are case-insensitive.</p>
      *
-     * The color codes from <code>1</code>-<code>f</code> can
-     * be used with an <code>&</code>.
+     * <p>The color codes from {@code 1}-{@code f} can
+     * be used with an {@code &}.
      * They behave exactly like the color codes
-     * Minecraft itself gives with the <code>§</code>. <br><br>
+     * Minecraft itself gives with the {@code §}. </p>
      *
-     * Also the attributes that make the message
-     * bold (<code>l</code>), italic (<code>o</code>),
-     * underlined (<code>n</code>), strikethrough (<code>m</code>)
+     * <p>Also the attributes that make the message
+     * bold ({@code l}), italic ({@code o}),
+     * underlined ({@code n}), strikethrough ({@code m})
      * can be used. These stack on top of each other
      * which means that a single segment can use
-     * multiple attributes: <code>&m&lmessage</code> <br><br>
+     * multiple attributes: {@code &m&lmessage}</p>
      *
-     * To reset all of the styles the code <code>r</code>
-     * can be used. <br>
+     * <p>To reset all of the styles the code {@code r}
+     * can be used.</p>
      *
-     * So a message with the standard Minecraft color codes
-     * would look like this: <br><br>
+     * <p>So a message with the standard Minecraft color codes
+     * would look like this:</p> <br>
      *
-     * <code>&4&lThis&r is a &1simple&r &8&nexamp&lle &4message</code>
+     * <pre>
+     *     {@code &4&lThis&r is a &1simple&r &8&nexamp&lle &4message}
+     * </pre>
      *
-     * <br><br>
+     * <br>
+     *
      * <!-- Separate the two parts -->
      * <hr>
+     * <br>
      *
-     * To use Hexadecimal colors the message must contain
-     * the identifier (which is <code>&</code>) and a
-     * <code>#</code> symbol. After that the hex
+     * <p>To use Hexadecimal colors the message must contain
+     * the identifier (which is {@code &}) and a
+     * {@code #} symbol. After that the hex
      * color code will start.
      * The hex color code will stop when there is
      * a character that is not in the range of
-     * <code>0</code>-<code>f</code> or there is a <code>;</code>. <br><br>
+     * {@code 0}-{@code f} or there is a {@code ;}. </p>
      *
-     * So when a message starts with a letter like an <code>a</code>
-     * the message should use a <code>;</code> so that this
-     * letter is not read as a part of the hex color code. <br><br>
+     * <p>So when a message starts with a letter like an {@code a}
+     * the message should use a {@code ;} so that this
+     * letter is not read as a part of the hex color code.</p>
      *
-     * When the hex color code is not valid it will be read
-     * as a normal string and included into the message. <br><br>
+     * <p>When the hex color code is not valid it will be read
+     * as a normal string and included into the message.</p>
      *
-     * So a message with hex color codes would look
-     * like this: <br><br>
+     * <p>So a message with hex color codes would look
+     * like this:</p> <br>
      *
-     * <code>&#da6000;A simple&r test &#B7088Amessage.</code><br><br>
+     * <pre>
+     *     {@code &#da6000;A simple&r test &#B7088Amessage.}
+     * </pre>
      *
      * <hr>
+     * <br>
      *
-     * Both of the ways of formatting a message - as seen
-     * in the previous example - can be used together.
+     * <p>Both of the ways of formatting a message - as seen
+     * in the previous example - can be used together.</p>
      *
      * @param message The raw message as a string
      * @return An array of TextComponents that resemble the message

--- a/src/main/java/net/quickwrite/noplayernotifier/utils/format/MessageIterator.java
+++ b/src/main/java/net/quickwrite/noplayernotifier/utils/format/MessageIterator.java
@@ -32,7 +32,7 @@ public class MessageIterator {
      *
      * <br><br>
      *
-     * Sets the identifier to the value <code>&</code>.
+     * Sets the identifier to the value {@code &}.
      *
      * @param message The message that should be iterated over.
      */


### PR DESCRIPTION
Edit the JavaDocs so that these are better to read and more information is carried out.

Also there are no warnings anymore about missing comments or missing arguments.

To generate these JavaDocs the user needs to use the Maven JavaDocs plugin and just use `mvn javadoc:javadoc`. When created the JavaDocs will just generate in **HTML** format.
